### PR TITLE
Add markdown responses for agents

### DIFF
--- a/.vitepress/config/hooks/generateMarkdown.ts
+++ b/.vitepress/config/hooks/generateMarkdown.ts
@@ -55,11 +55,9 @@ function createLlmsTxt(pages: MarkdownPage[], hostname: string) {
 
   for (const page of pages) {
     const title = normalizeText(page.frontmatter.title)
-    const pageDescription = normalizeText(page.frontmatter.description)
     const markdownUrl = `${hostname}${markdownPublicPath(page.url)}`
-    const suffix = pageDescription ? `: ${pageDescription}` : ''
 
-    lines.push(`- [${escapeLinkText(title)}](${markdownUrl})${suffix}`)
+    lines.push(`- [${escapeLinkText(title)}](${markdownUrl}): ${title}`)
   }
 
   return `${lines.join('\n')}\n`

--- a/.vitepress/config/hooks/generateMarkdown.ts
+++ b/.vitepress/config/hooks/generateMarkdown.ts
@@ -1,0 +1,112 @@
+import path from 'path'
+import { mkdirSync, writeFileSync } from 'fs'
+import { createContentLoader, type SiteConfig } from 'vitepress'
+
+type MarkdownPage = {
+  url: string
+  src?: string
+  frontmatter: Record<string, any>
+}
+
+async function generateMarkdown(config: SiteConfig, hostname: string) {
+  const pages = await createContentLoader<MarkdownPage[]>('../src/**/*.md', {
+    includeSrc: true
+  }).load()
+
+  const markdownPages = pages.filter((page) => page.src)
+  const publishedPages = markdownPages
+    .filter((page) => page.frontmatter.title)
+    .sort(sortPages)
+
+  for (const page of markdownPages) {
+    writeMarkdownPage(config.outDir, page)
+  }
+
+  writeFileSync(
+    path.join(config.outDir, 'llms.txt'),
+    createLlmsTxt(publishedPages, hostname)
+  )
+}
+
+function writeMarkdownPage(outDir: string, page: MarkdownPage) {
+  const destination = path.join(outDir, markdownOutputPath(page.url))
+
+  mkdirSync(path.dirname(destination), { recursive: true })
+  writeFileSync(destination, ensureTrailingNewline(page.src || ''))
+}
+
+function createLlmsTxt(pages: MarkdownPage[], hostname: string) {
+  const homepage = pages.find((page) => page.url === '/')
+  const description = normalizeText(
+    homepage?.frontmatter.description ||
+      'Developer with a passion for writing clean and functional code, and bringing beautiful ideas to life'
+  )
+
+  const lines = [
+    '# Paul Laros',
+    '',
+    `> ${description}`,
+    '',
+    'This site supports Markdown content negotiation. Send `Accept: text/markdown` to any page URL, or use the Markdown links below.',
+    '',
+    '## Pages',
+    ''
+  ]
+
+  for (const page of pages) {
+    const title = normalizeText(page.frontmatter.title)
+    const pageDescription = normalizeText(page.frontmatter.description)
+    const markdownUrl = `${hostname}${markdownPublicPath(page.url)}`
+    const suffix = pageDescription ? `: ${pageDescription}` : ''
+
+    lines.push(`- [${escapeLinkText(title)}](${markdownUrl})${suffix}`)
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+function sortPages(a: MarkdownPage, b: MarkdownPage) {
+  if (a.url === '/') return -1
+  if (b.url === '/') return 1
+
+  const dateA = Date.parse(a.frontmatter.date || '')
+  const dateB = Date.parse(b.frontmatter.date || '')
+
+  if (!Number.isNaN(dateA) && !Number.isNaN(dateB) && dateA !== dateB) {
+    return dateB - dateA
+  }
+
+  return normalizeText(a.frontmatter.title).localeCompare(
+    normalizeText(b.frontmatter.title)
+  )
+}
+
+function markdownOutputPath(url: string) {
+  if (url === '/') return 'index.md'
+  if (url.endsWith('/')) return `${url.slice(1)}index.md`
+
+  return `${url.slice(1)}.md`
+}
+
+function markdownPublicPath(url: string) {
+  if (url === '/') return '/index.md'
+  if (url.endsWith('/')) return `${url}index.md`
+
+  return `${url}.md`
+}
+
+function normalizeText(value: unknown) {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function escapeLinkText(value: string) {
+  return value.replace(/[[\]]/g, '\\$&')
+}
+
+function ensureTrailingNewline(value: string) {
+  return value.endsWith('\n') ? value : `${value}\n`
+}
+
+export default generateMarkdown

--- a/.vitepress/config/hooks/generateMarkdown.ts
+++ b/.vitepress/config/hooks/generateMarkdown.ts
@@ -57,7 +57,7 @@ function createLlmsTxt(pages: MarkdownPage[], hostname: string) {
     const title = normalizeText(page.frontmatter.title)
     const markdownUrl = `${hostname}${markdownPublicPath(page.url)}`
 
-    lines.push(`- [${escapeLinkText(title)}](${markdownUrl}): ${title}`)
+    lines.push(`- [${escapeLinkText(title)}](${markdownUrl})`)
   }
 
   return `${lines.join('\n')}\n`

--- a/.vitepress/config/index.ts
+++ b/.vitepress/config/index.ts
@@ -6,6 +6,7 @@ import head from "./head"
 
 import generateMeta from './hooks/generateMeta'
 import generateFeed from './hooks/generateFeed'
+import generateMarkdown from './hooks/generateMarkdown'
 
 const hostname: string = 'https://laros.io'
 
@@ -26,7 +27,10 @@ export default defineConfig({
     generateMeta(context, hostname)
   ),
   buildEnd: async (context) => {
-    generateFeed(context, hostname)
+    await Promise.all([
+      generateFeed(context, hostname),
+      generateMarkdown(context, hostname)
+    ])
   },
   markdown: {
     config: (md) => {

--- a/.vitepress/config/theme.ts
+++ b/.vitepress/config/theme.ts
@@ -28,6 +28,10 @@ const themeConfig: DefaultTheme.Config = {
       text: 'Contact',
       link: 'mailto:hey@laros.io',
     },
+    {
+      text: 'llms.txt',
+      link: '/llms.txt',
+    },
   ],
   sidebar: [
     {

--- a/.vitepress/config/theme.ts
+++ b/.vitepress/config/theme.ts
@@ -31,6 +31,7 @@ const themeConfig: DefaultTheme.Config = {
     {
       text: 'llms.txt',
       link: '/llms.txt',
+      target: '_blank',
     },
   ],
   sidebar: [

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,138 @@
+import { next } from '@vercel/functions'
+
+const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8'
+const NEGOTIATED_METHODS = new Set(['GET', 'HEAD'])
+const STATIC_PREFIXES = ['/assets/', '/fonts/', '/images/']
+const STATIC_PATHS = new Set([
+  '/favicon.ico',
+  '/feed.rss',
+  '/robots.txt',
+  '/sitemap.xml'
+])
+
+export const config = {
+  matcher: ['/((?!assets/|fonts/|images/|favicon.ico|feed.rss|robots.txt|sitemap.xml).*)']
+}
+
+export default async function middleware(request: Request) {
+  if (!NEGOTIATED_METHODS.has(request.method)) {
+    return next()
+  }
+
+  const url = new URL(request.url)
+
+  if (url.pathname === '/llms.txt') {
+    return next({
+      headers: {
+        'Content-Type': MARKDOWN_CONTENT_TYPE
+      }
+    })
+  }
+
+  const markdownPath = getMarkdownPath(url.pathname)
+
+  if (!markdownPath) {
+    return next()
+  }
+
+  const linkHeader = `<${markdownPath}>; rel="alternate"; type="text/markdown"`
+
+  if (url.pathname.endsWith('.md')) {
+    return next({
+      headers: {
+        'Content-Type': MARKDOWN_CONTENT_TYPE,
+        Vary: 'Accept'
+      }
+    })
+  }
+
+  if (!acceptsMarkdown(request.headers.get('Accept'))) {
+    return next({
+      headers: {
+        Link: linkHeader,
+        Vary: 'Accept'
+      }
+    })
+  }
+
+  const markdownUrl = new URL(markdownPath, request.url)
+  const markdownResponse = await fetch(markdownUrl, {
+    headers: {
+      Accept: MARKDOWN_CONTENT_TYPE
+    }
+  })
+
+  if (!markdownResponse.ok) {
+    return next({
+      headers: {
+        Link: linkHeader,
+        Vary: 'Accept'
+      }
+    })
+  }
+
+  const markdown = await markdownResponse.text()
+  const headers = new Headers({
+    'Content-Type': MARKDOWN_CONTENT_TYPE,
+    Link: linkHeader,
+    Vary: 'Accept',
+    'x-markdown-tokens': estimateTokens(markdown).toString()
+  })
+  const cacheControl = markdownResponse.headers.get('Cache-Control')
+
+  if (cacheControl) {
+    headers.set('Cache-Control', cacheControl)
+  }
+
+  return new Response(request.method === 'HEAD' ? null : markdown, {
+    status: markdownResponse.status,
+    headers
+  })
+}
+
+function getMarkdownPath(pathname: string) {
+  if (isStaticPath(pathname)) return null
+  if (pathname.endsWith('.md')) return pathname
+  if (hasFileExtension(pathname)) return null
+  if (pathname === '/') return '/index.md'
+  if (pathname.endsWith('/')) return `${pathname}index.md`
+
+  return `${pathname}.md`
+}
+
+function isStaticPath(pathname: string) {
+  return (
+    STATIC_PATHS.has(pathname) ||
+    STATIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  )
+}
+
+function hasFileExtension(pathname: string) {
+  return /\/[^/]+\.[^/]+$/.test(pathname)
+}
+
+function acceptsMarkdown(acceptHeader: string | null) {
+  if (!acceptHeader) return false
+
+  return acceptHeader.split(',').some((part) => {
+    const [mediaType, ...parameters] = part
+      .trim()
+      .toLowerCase()
+      .split(';')
+      .map((value) => value.trim())
+
+    if (mediaType !== 'text/markdown') return false
+
+    const quality = parameters
+      .find((parameter) => parameter.startsWith('q='))
+      ?.slice(2)
+
+    return quality === undefined || Number.parseFloat(quality) > 0
+  })
+}
+
+function estimateTokens(markdown: string) {
+  const words = markdown.trim().split(/\s+/).filter(Boolean).length
+
+  return Math.max(1, Math.ceil(words * 1.33))
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,27 +1,16 @@
-import { next } from '@vercel/functions'
+import { next, rewrite } from '@vercel/functions'
 
 const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8'
-const NEGOTIATED_METHODS = new Set(['GET', 'HEAD'])
-const STATIC_PREFIXES = ['/assets/', '/fonts/', '/images/']
-const STATIC_PATHS = new Set([
-  '/favicon.ico',
-  '/feed.rss',
-  '/robots.txt',
-  '/sitemap.xml'
-])
 
 export const config = {
   matcher: ['/((?!assets/|fonts/|images/|favicon.ico|feed.rss|robots.txt|sitemap.xml).*)']
 }
 
-export default async function middleware(request: Request) {
-  if (!NEGOTIATED_METHODS.has(request.method)) {
-    return next()
-  }
-
+export default function middleware(request: Request) {
   const url = new URL(request.url)
+  const { pathname } = url
 
-  if (url.pathname === '/llms.txt') {
+  if (pathname === '/llms.txt' || pathname.endsWith('.md')) {
     return next({
       headers: {
         'Content-Type': MARKDOWN_CONTENT_TYPE
@@ -29,110 +18,36 @@ export default async function middleware(request: Request) {
     })
   }
 
-  const markdownPath = getMarkdownPath(url.pathname)
-
-  if (!markdownPath) {
+  if (
+    (request.method !== 'GET' && request.method !== 'HEAD') ||
+    /\/[^/]+\.[^/]+$/.test(pathname)
+  ) {
     return next()
   }
 
+  let markdownPath = `${pathname}.md`
+
+  if (pathname === '/') {
+    markdownPath = '/index.md'
+  } else if (pathname.endsWith('/')) {
+    markdownPath = `${pathname}index.md`
+  }
+
   const linkHeader = `<${markdownPath}>; rel="alternate"; type="text/markdown"`
-
-  if (url.pathname.endsWith('.md')) {
-    return next({
-      headers: {
-        'Content-Type': MARKDOWN_CONTENT_TYPE,
-        Vary: 'Accept'
-      }
-    })
+  const headers = {
+    Link: linkHeader,
+    Vary: 'Accept'
   }
 
-  if (!acceptsMarkdown(request.headers.get('Accept'))) {
-    return next({
-      headers: {
-        Link: linkHeader,
-        Vary: 'Accept'
-      }
-    })
+  if (!request.headers.get('Accept')?.toLowerCase().includes('text/markdown')) {
+    return next({ headers })
   }
 
-  const markdownUrl = new URL(markdownPath, request.url)
-  const markdownResponse = await fetch(markdownUrl, {
+  url.pathname = markdownPath
+  return rewrite(url, {
     headers: {
-      Accept: MARKDOWN_CONTENT_TYPE
+      ...headers,
+      'Content-Type': MARKDOWN_CONTENT_TYPE
     }
   })
-
-  if (!markdownResponse.ok) {
-    return next({
-      headers: {
-        Link: linkHeader,
-        Vary: 'Accept'
-      }
-    })
-  }
-
-  const markdown = await markdownResponse.text()
-  const headers = new Headers({
-    'Content-Type': MARKDOWN_CONTENT_TYPE,
-    Link: linkHeader,
-    Vary: 'Accept',
-    'x-markdown-tokens': estimateTokens(markdown).toString()
-  })
-  const cacheControl = markdownResponse.headers.get('Cache-Control')
-
-  if (cacheControl) {
-    headers.set('Cache-Control', cacheControl)
-  }
-
-  return new Response(request.method === 'HEAD' ? null : markdown, {
-    status: markdownResponse.status,
-    headers
-  })
-}
-
-function getMarkdownPath(pathname: string) {
-  if (isStaticPath(pathname)) return null
-  if (pathname.endsWith('.md')) return pathname
-  if (hasFileExtension(pathname)) return null
-  if (pathname === '/') return '/index.md'
-  if (pathname.endsWith('/')) return `${pathname}index.md`
-
-  return `${pathname}.md`
-}
-
-function isStaticPath(pathname: string) {
-  return (
-    STATIC_PATHS.has(pathname) ||
-    STATIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))
-  )
-}
-
-function hasFileExtension(pathname: string) {
-  return /\/[^/]+\.[^/]+$/.test(pathname)
-}
-
-function acceptsMarkdown(acceptHeader: string | null) {
-  if (!acceptHeader) return false
-
-  return acceptHeader.split(',').some((part) => {
-    const [mediaType, ...parameters] = part
-      .trim()
-      .toLowerCase()
-      .split(';')
-      .map((value) => value.trim())
-
-    if (mediaType !== 'text/markdown') return false
-
-    const quality = parameters
-      .find((parameter) => parameter.startsWith('q='))
-      ?.slice(2)
-
-    return quality === undefined || Number.parseFloat(quality) > 0
-  })
-}
-
-function estimateTokens(markdown: string) {
-  const words = markdown.trim().split(/\s+/).filter(Boolean).length
-
-  return Math.max(1, Math.ceil(words * 1.33))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vercel/analytics": "1.3.1",
+        "@vercel/functions": "3.6.0",
         "autoprefixer": "10.4.20",
         "feed": "4.2.2",
         "gsap": "3.12.5",
@@ -158,6 +159,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.9.1.tgz",
       "integrity": "sha512-YWPGDyISFNbPFVswI16c4rgt2CeTgFk82e543FSyw/3H5eNKa0YPb876GguEb50NualXCF7DCuVhcp6XMTpaSg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.0.0"
       }
@@ -277,6 +279,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.9.1.tgz",
       "integrity": "sha512-EevzJJ2AXu+U2w14XgK9GnJn9Y4q5GNnoAUWS0aErCCb7XhYiM7xa1eJnVq+FoOwRuZj8RmS4GEV7t3CQI3TqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.9.1"
       },
@@ -295,6 +298,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.9.1.tgz",
       "integrity": "sha512-gBSi8QotBfOu3BbF25PB2uVbCNfrjVDGyvfeIQ6DukUldjEE8ruusNJnVMHoR00rO1C8G86/USHkbmXx73vf7Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.9.1"
       },
@@ -307,6 +311,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.9.1.tgz",
       "integrity": "sha512-ImECpAR0A0q+9UfTprA099JJ6VZ+GjUoOC+m5rbyJieA4rUbt/A6QHkqeUq/2fObeezOzLn4DZDAXW93YHM+oQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.9.1"
       },
@@ -843,157 +848,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@next/env": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.15.tgz",
-      "integrity": "sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.15.tgz",
-      "integrity": "sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
-      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
-      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
-      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
-      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
-      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
-      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
-      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
-      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1294,24 +1148,6 @@
       "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
       "license": "MIT"
     },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1395,6 +1231,35 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.6.0.tgz",
+      "integrity": "sha512-Xj68JYqqJwtqFWJN7EWmFN7MOiUjv5whjw48UEKqQbg8r7hRkhuJhncTU0ba3jJCh/wxEuLWckrtsKcrHQraxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.4.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.1.tgz",
+      "integrity": "sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -1715,7 +1580,6 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
       "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/cache-browser-local-storage": "4.24.0",
         "@algolia/cache-common": "4.24.0",
@@ -1893,7 +1757,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -1905,18 +1768,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "optional": true,
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/camelcase-css": {
@@ -2013,13 +1864,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/client-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2240,7 +2084,6 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
       "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -2312,13 +2155,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/gsap": {
       "version": "3.12.5",
@@ -2472,13 +2308,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -2491,19 +2320,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.12",
@@ -2705,86 +2521,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/next": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
-      "integrity": "sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@next/env": "14.2.15",
-        "@swc/helpers": "0.5.5",
-        "busboy": "1.6.0",
-        "caniuse-lite": "^1.0.30001579",
-        "graceful-fs": "^4.2.11",
-        "postcss": "8.4.31",
-        "styled-jsx": "5.1.1"
-      },
-      "bin": {
-        "next": "dist/bin/next"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      },
-      "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.15",
-        "@next/swc-darwin-x64": "14.2.15",
-        "@next/swc-linux-arm64-gnu": "14.2.15",
-        "@next/swc-linux-arm64-musl": "14.2.15",
-        "@next/swc-linux-x64-gnu": "14.2.15",
-        "@next/swc-linux-x64-musl": "14.2.15",
-        "@next/swc-win32-arm64-msvc": "14.2.15",
-        "@next/swc-win32-ia32-msvc": "14.2.15",
-        "@next/swc-win32-x64-msvc": "14.2.15"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "sass": "^1.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@playwright/test": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
@@ -2914,7 +2650,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -3192,16 +2927,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
       "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
     },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/search-insights": {
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.2.tgz",
@@ -3256,15 +2981,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -3277,30 +2993,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/styled-jsx": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "client-only": "0.0.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
       }
     },
     "node_modules/sucrase": {
@@ -3443,20 +3135,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
-    },
-    "node_modules/tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
-      "license": "0BSD",
-      "optional": true
-    },
-    "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/unist-util-is": {
       "version": "6.0.0",
@@ -3647,7 +3325,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
       "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3707,7 +3384,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.12.tgz",
       "integrity": "sha512-CLVZtXtn2ItBIi/zHZ0Sg1Xkb7+PU32bJJ8Bmy7ts3jxXTcbfsEfBivFYYWz1Hur+lalqGAh65Coin0r+HRUfg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.12",
         "@vue/compiler-sfc": "3.5.12",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "1.3.1",
+    "@vercel/functions": "3.6.0",
     "autoprefixer": "10.4.20",
     "feed": "4.2.2",
     "gsap": "3.12.5",

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -31,3 +31,4 @@ Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /
 
 Sitemap: https://laros.io/sitemap.xml
+Sitemap: https://laros.io/feed.rss


### PR DESCRIPTION
## Summary

Adds Markdown-for-agents support for the VitePress site while keeping browser HTML as the default response.

## Changes

- Generates .md page artifacts and a dynamic llms.txt during vitepress build.
- Adds Vercel routing middleware that serves markdown when requests include Accept: text/markdown.
- Sets markdown response headers, including Content-Type: text/markdown; charset=utf-8 and x-markdown-tokens.
- Adds alternate markdown Link headers for regular HTML requests.

## Validation

- Ran npm run build successfully.
- Bundled and simulated the middleware locally to verify HTML fallback headers and markdown negotiation headers.